### PR TITLE
docs(readme): Fix Mermaid diagram syntax comprehensively

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ flowchart LR
 
     subgraph "MCP-Tx Servers"
         direction TB
-        Server1[Automated Server (AI/API)]
-        Server2[Human Operator (via UI)]
+        Server1["Automated Server (AI/API)"]
+        Server2["Human Operator (via UI)"]
     end
 
     A -- MCP-Tx Request --> Server1


### PR DESCRIPTION
Fixes a recurring Mermaid syntax error in the README.md diagram. The parser was failing on all nodes where the text contained special characters like parentheses.

This change encloses all such node texts in double quotes to ensure they are parsed correctly as string literals. This resolves the issue comprehensively.